### PR TITLE
Fix example and add troubleshooting section

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ time.
 Here's a lock using i3lock, with screen dim support:
 
 #+BEGIN_SRC sh
-#!/usr/env/bin bash
+#!/usr/bin/env bash
 
 # Only exported variables can be used within the timer's command.
 export PRIMARY_DISPLAY="$(xrandr | awk '/ primary/{print $1}')"

--- a/README.org
+++ b/README.org
@@ -148,3 +148,8 @@ xidlehook-client --socket /path/to/xidlehook.sock control --action trigger --tim
 If you're looking for a more elaborate client to temporarily disable
 =xidlehook=, take a look at [[https://github.com/rschmukler/caffeinate][caffeinate]] which has timers and PID based
 monitoring.
+
+** Troubleshooting
+
+If you have =redshift= running, the brightness of your screen will be quickly overriden by =redshift=.
+You can specify the brightness of the screen via =redshift= instead of =xrandr= to fix this issue.


### PR DESCRIPTION
Hello,

Thanks a lot for `xidlehook`, this is an awesome software!

I've noticed a small typo in the `README.md` were you use `/usr/env/bin` instead of `/usr/bin/env` in the shebang.

Also, when first trying this script, my screen brightness kept being overridden. After investigating, I noticed `redshift` was the one overriding the `xrandr` settings. I added a troubleshooting section to the readme as `redshift` is quite a common software and someone else might encounter the issue.

Feel free to cherry-pick any of those commits.